### PR TITLE
Improve performance using parallelized iter

### DIFF
--- a/native/bls/Cargo.lock
+++ b/native/bls/Cargo.lock
@@ -65,6 +65,7 @@ dependencies = [
  "group",
  "hex",
  "pairing",
+ "rayon",
  "rustler",
  "sha2",
 ]

--- a/native/bls/Cargo.toml
+++ b/native/bls/Cargo.toml
@@ -18,3 +18,4 @@ bls12_381 = { version = "0.8.0", features = ["experimental"] }
 pairing = "0.23.0"
 group = "0.13.0"
 sha2 = "0.10.8"
+rayon = "1.10.0"

--- a/native/bls/src/keys.rs
+++ b/native/bls/src/keys.rs
@@ -5,6 +5,7 @@ use crate::signature::Signature;
 use bls12_381::{G1Affine, G1Projective, Scalar};
 use group::Curve;
 use pairing::PairingCurveAffine;
+use rayon::prelude::*;
 
 pub struct PublicKey(pub(crate) G1Projective);
 pub struct SecretKey(pub(crate) Scalar);
@@ -76,13 +77,13 @@ impl PublicKey {
         }
 
         let sum = pks
-            .into_iter()
+            .into_par_iter()
             .map(|public_key| {
                 let t = h1(&public_key);
                 let gx = public_key.0 * t;
                 G1Projective::from(gx)
             })
-            .fold(G1Projective::default(), |acc, next| acc + next);
+            .reduce(G1Projective::default, |acc, next| acc + next);
 
         let agg_pub = G1Projective::from(sum);
         Ok(Self(agg_pub))

--- a/test/bls_ex_test.exs
+++ b/test/bls_ex_test.exs
@@ -11,4 +11,28 @@ defmodule BlsExTest do
       assert BlsEx.verify_signature?(public_key, "hello", signature)
     end
   end
+
+  property "cryptographic material should work with aggregated keys" do
+    data = "hello"
+
+    check all(seeds <- random_list_of_seeds()) do
+      {public_keys, signatures} =
+        seeds
+        |> Enum.map(fn seed ->
+          signature = BlsEx.sign!(seed, data)
+          public_key = BlsEx.get_public_key!(seed)
+          {public_key, signature}
+        end)
+        |> Enum.unzip()
+
+      agg_signature = BlsEx.aggregate_signatures!(signatures, public_keys)
+      agg_public_keys = BlsEx.aggregate_public_keys!(public_keys)
+
+      assert BlsEx.verify_signature?(agg_public_keys, data, agg_signature)
+    end
+  end
+
+  defp random_list_of_seeds() do
+    StreamData.list_of(StreamData.binary(length: 64), min_length: 2, max_length: 25)
+  end
 end


### PR DESCRIPTION
Improve performance using `par_iter` from rayon lib.
Benchmark on `aggregate_public_keys`
Same performance gain on `aggregate_signatures`
```text
##### With input 1 #####
Name                                ips        average  deviation         median         99th %
aggregate parallel iter          2.29 K      436.72 μs     ±7.22%      430.67 μs      583.51 μs
aggregate sequential iter        2.25 K      445.18 μs     ±4.52%      443.94 μs      471.41 μs

Comparison:
aggregate parallel iter          2.29 K
aggregate sequential iter        2.25 K - 1.02x slower +8.45 μs

##### With input 3 #####
Name                                ips        average  deviation         median         99th %
aggregate parallel iter          1.66 K        0.60 ms    ±23.47%        0.54 ms        1.01 ms
aggregate sequential iter        0.79 K        1.27 ms     ±4.82%        1.26 ms        1.33 ms

Comparison:
aggregate parallel iter          1.66 K
aggregate sequential iter        0.79 K - 2.11x slower +0.67 ms

##### With input 5 #####
Name                                ips        average  deviation         median         99th %
aggregate parallel iter          1.21 K        0.82 ms    ±23.77%        0.92 ms        1.06 ms
aggregate sequential iter        0.48 K        2.08 ms     ±0.94%        2.07 ms        2.14 ms

Comparison:
aggregate parallel iter          1.21 K
aggregate sequential iter        0.48 K - 2.52x slower +1.25 ms

##### With input 10 #####
Name                                ips        average  deviation         median         99th %
aggregate parallel iter          955.18        1.05 ms     ±8.59%        1.03 ms        1.50 ms
aggregate sequential iter        243.30        4.11 ms     ±0.84%        4.11 ms        4.22 ms

Comparison:
aggregate parallel iter          955.18
aggregate sequential iter        243.30 - 3.93x slower +3.06 ms

##### With input 50 #####
Name                                ips        average  deviation         median         99th %
aggregate parallel iter          261.52        3.82 ms     ±6.92%        3.77 ms        4.52 ms
aggregate sequential iter         49.07       20.38 ms     ±0.63%       20.35 ms       21.11 ms

Comparison:
aggregate parallel iter          261.52
aggregate sequential iter         49.07 - 5.33x slower +16.55 ms

##### With input 100 #####
Name                                ips        average  deviation         median         99th %
aggregate parallel iter          140.59        7.11 ms     ±3.14%        7.10 ms        7.77 ms
aggregate sequential iter         24.62       40.62 ms     ±0.34%       40.60 ms       41.16 ms

Comparison:
aggregate parallel iter          140.59
aggregate sequential iter         24.62 - 5.71x slower +33.51 ms

##### With input 150 #####
Name                                ips        average  deviation         median         99th %
aggregate parallel iter           88.74       11.27 ms     ±5.62%       11.46 ms       12.51 ms
aggregate sequential iter         16.39       61.00 ms     ±1.13%       60.87 ms       66.62 ms

Comparison:
aggregate parallel iter           88.74
aggregate sequential iter         16.39 - 5.41x slower +49.73 ms

##### With input 200 #####
Name                                ips        average  deviation         median         99th %
aggregate parallel iter           66.21       15.10 ms     ±2.54%       15.03 ms       16.55 ms
aggregate sequential iter         12.46       80.29 ms     ±0.59%       80.37 ms       81.81 ms

Comparison:
aggregate parallel iter           66.21
aggregate sequential iter         12.46 - 5.32x slower +65.18 ms

```